### PR TITLE
[Refactor] MyNetflixViewModel 구조 개선

### DIFF
--- a/Uflix/Scene/MyNetflix/FavoriteMovieCell.swift
+++ b/Uflix/Scene/MyNetflix/FavoriteMovieCell.swift
@@ -71,7 +71,7 @@ class FavoriteMovieCell: UICollectionViewCell {
         
         imageView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(imageView.snp.width).multipliedBy(1.5) // 2:3 비율
+            $0.height.equalTo(imageView.snp.width).multipliedBy(1.5)
         }
         
         titleLabel.snp.makeConstraints {

--- a/Uflix/Scene/MyNetflix/FavoriteMovieCell.swift
+++ b/Uflix/Scene/MyNetflix/FavoriteMovieCell.swift
@@ -90,8 +90,10 @@ class FavoriteMovieCell: UICollectionViewCell {
         }
     }
     
-    func configure(movie: FavoriteMovie) {
+    func configure(movie: FavoriteMovie, isEditing: Bool, isSelected: Bool) {
         titleLabel.text = movie.title
+        self.isEditing = isEditing
+        self.isSelected = isSelected
         
         if let path = movie.posterPath {
             let url = URL(string: "https://image.tmdb.org/t/p/w500\(path)")
@@ -102,6 +104,7 @@ class FavoriteMovieCell: UICollectionViewCell {
         
         updateCheckUI()
     }
+
     
     private func updateCheckUI() {
         let show = isEditing && isSelected

--- a/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
+++ b/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
@@ -185,7 +185,13 @@ class MyNetflixViewController: BaseViewController {
                 }
             })
             .disposed(by: disposeBag)
-        
+       
+        output.showDeleteAlert
+            .emit(onNext: { [weak self] in
+                self?.showDeleteConfirmationAlert()
+            })
+            .disposed(by: disposeBag)
+
         output.selectedMovie
             .emit(onNext: { [weak self] movie in
                 self?.navigateToDetail(for: movie)
@@ -193,6 +199,22 @@ class MyNetflixViewController: BaseViewController {
             .disposed(by: disposeBag)
         
     }
+    
+    private func showDeleteConfirmationAlert() {
+        let alert = UIAlertController(
+            title: "정말 삭제하시겠어요?",
+            message: "선택한 영화들이 삭제됩니다.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "삭제", style: .destructive, handler: { [weak self] _ in
+            self?.viewModel.performDeletion()
+        }))
+
+        present(alert, animated: true, completion: nil)
+    }
+
     
     private func navigateToDetail(for movie: FavoriteMovie) {
         let model = Movie(

--- a/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
+++ b/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
@@ -65,20 +65,19 @@ class MyNetflixViewController: BaseViewController {
     private func createLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0 / 3),
-            heightDimension: .estimated(180)
+            heightDimension: .fractionalWidth(1.0 / 3 * 1.8)
         )
         
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(180)
+            heightDimension: itemSize.heightDimension
         )
         
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
-            repeatingSubitem: item,
-            count: 3
+            subitems: [item]
         )
         
         group.interItemSpacing = .fixed(10)

--- a/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
+++ b/Uflix/Scene/MyNetflix/MyNetflixViewController.swift
@@ -56,11 +56,6 @@ class MyNetflixViewController: BaseViewController {
         setupUI()
         bind()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.fetchFavorites()
-    }
 
     private func createLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(
@@ -135,94 +130,68 @@ class MyNetflixViewController: BaseViewController {
     
     private func bind() {
         let input = MyNetflixViewModel.Input(
-            editButtonTapped: editButton.rx.tap.asObservable()
+            viewWillAppearTrigger: rx.methodInvoked(#selector(viewWillAppear(_:))).map { _ in },
+            editButtonTapped: editButton.rx.tap.asObservable(),
+            doneButtonTapped: doneButton.rx.tap.asObservable(),
+            deleteButtonTapped: deleteButton.rx.tap.asObservable(),
+            itemSelected: collectionView.rx.itemSelected.asObservable(),
+            itemDeselected: collectionView.rx.itemDeselected.asObservable()
         )
         
         let output = viewModel.transform(input: input)
         
-        // 버튼 이벤트 처리
-        editButton.rx.tap
-            .bind(onNext: { [weak self] in
-                self?.editButton.isHidden = true
-                self?.editStackView.isHidden = false
-                self?.viewModel.isEditingRelay.accept(true)
-            }).disposed(by: disposeBag)
-        
-        doneButton.rx.tap
-            .bind(onNext: { [weak self] in
-                guard let self = self else { return }
-                self.editStackView.isHidden = true
-                self.editButton.isHidden = false
-                self.viewModel.isEditingRelay.accept(false)
-                self.viewModel.selectedIDsRelay.accept([])
-                
-                // 셀 선택 해제
-                for indexPath in self.collectionView.indexPathsForSelectedItems ?? [] {
-                    self.collectionView.deselectItem(at: indexPath, animated: false)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        // todo: 삭제 alert
-        deleteButton.rx.tap
-            .withLatestFrom(viewModel.selectedIDsRelay.asObservable())
-            .bind(onNext: { [weak self] selectedIDs in
-                guard let self = self else { return }
-                let moviesToDelete = self.viewModel.allMovies.value.filter {
-                    selectedIDs.contains(Int($0.id))
-                }
-                moviesToDelete.forEach {
-                    self.viewModel.deleteFavorite($0)
-                }
-                self.viewModel.selectedIDsRelay.accept([])
-            })
-            .disposed(by: disposeBag)
-        
-        output.isEditing
-            .drive(onNext: { [weak self] _ in
-                self?.collectionView.reloadData()
-            })
-            .disposed(by: disposeBag)
-        
+        // 1. 영화 목록 바인딩
         output.movies
             .drive(collectionView.rx.items(
                 cellIdentifier: FavoriteMovieCell.identifier,
                 cellType: FavoriteMovieCell.self
-            )) { [weak self] index, movie, cell in
-                cell.configure(movie: movie)
-                cell.isEditing = self?.viewModel.isEditingRelay.value ?? false
-            }.disposed(by: disposeBag)
+            )) { index, movie, cell in
+                cell.configure(movie: movie, isEditing: false, isSelected: false)
+            }
+            .disposed(by: disposeBag)
         
-        collectionView.rx.itemSelected
-            .subscribe(onNext: { [weak self] indexPath in
+        // 2. 편집 모드 상태 → 버튼 UI 전환 및 reloadData
+        output.isEditing
+            .drive(onNext: { [weak self] isEditing in
+                guard let self = self else { return }
+                self.editButton.isHidden = isEditing
+                self.editStackView.isHidden = !isEditing
+                self.collectionView.reloadData()
+            })
+            .disposed(by: disposeBag)
+        
+        // 3. 선택된 셀만 reload → check 표시 반영
+        Observable
+            .combineLatest(output.movies.asObservable(), output.selectedIDs.asObservable(), output.isEditing.asObservable())
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] movies, selectedIDs, isEditing in
                 guard let self = self else { return }
                 
-                let movie = self.viewModel.allMovies.value[indexPath.item]
-                
-                if self.viewModel.isEditingRelay.value {
-                    var selected = self.viewModel.selectedIDsRelay.value
-                    selected.insert(Int(movie.id))
-                    self.viewModel.selectedIDsRelay.accept(selected)
+                for (index, movie) in movies.enumerated() {
+                    let indexPath = IndexPath(item: index, section: 0)
+                    guard let cell = self.collectionView.cellForItem(at: indexPath) as? FavoriteMovieCell else { continue }
                     
-                    print("✅ 선택된 셀: \(movie.title ?? "제목 없음") (id: \(movie.id))")
-                    print("📌 현재 selectedIDsRelay: \(selected)")
-                } else {
-                    self.navigateToDetail(for: movie)
-                    self.collectionView.deselectItem(at: indexPath, animated: false)
+                    let isSelected = selectedIDs.contains(Int(movie.id))
+                    cell.configure(movie: movie, isEditing: isEditing, isSelected: isSelected)
+                    
+                    if isSelected {
+                        print("✅ 선택된 셀: \(movie.title ?? "제목 없음") (id: \(movie.id))")
+                    }
+                    let selectedMovies = movies.filter { selectedIDs.contains(Int($0.id)) }
+                    print("❗️ 선택된 셀 전체 (\(selectedMovies.count)개):")
+                    selectedMovies.forEach { movie in
+                        print("• \(movie.title ?? "제목 없음")")
+                    }
                 }
             })
             .disposed(by: disposeBag)
         
-        collectionView.rx.itemDeselected
-            .subscribe(onNext: { [weak self] indexPath in
-                guard let self = self else { return }
-                let movie = self.viewModel.allMovies.value[indexPath.item]
-                let id = Int(movie.id)
-                var selected = self.viewModel.selectedIDsRelay.value
-                selected.remove(id)
-                self.viewModel.selectedIDsRelay.accept(selected)
+        output.selectedMovie
+            .emit(onNext: { [weak self] movie in
+                self?.navigateToDetail(for: movie)
             })
             .disposed(by: disposeBag)
+        
     }
     
     private func navigateToDetail(for movie: FavoriteMovie) {


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: [Feature] 검색 화면 UI 구현 -->
MyNetflixViewModel Input/Output 구조 전면 개편 및 편집/상세 전환 기능 분리

## 🚀 Description
- Output 구조 내 selectedMovie 잘못된 초기화 방식 수정 (selectedMovieRelay → 외부에서 초기화)
- Input에 편집/완료/삭제 버튼, 셀 선택/해제, 뷰 진입 트리거 등 사용자 상호작용 전반 추가
- Output에 selectedMovie Signal 추가로, 편집 모드 외 선택 시 상세 화면 전환 가능하게 처리
- movie 선택 시 편집 모드 여부에 따라 분기 처리: 편집 모드면 체크만, 아니면 selectedMovie 전달
- 내부 상태를 모두 private Relay로 수정하고, 상태 변화를 Output으로만 전달
- 불필요한 바인딩 중복 제거 및 명확한 데이터 흐름 구조화
- ViewController에서도 기존 bind 구조를 Input/Output 중심으로 재정비
- 삭제 Alert 추가

## 🔍 Related Issue
- 이슈 번호: #25

## 📸 Screenshot
|    기능    |   이미지   |
| :-------------: | :----------: |
| GIF | <img src = "" width ="250">|

## 📢 Notes

