### PR TITLE
[Feat] DetailView 추천 콘텐츠

### DIFF
--- a/Uflix.xcodeproj/project.pbxproj
+++ b/Uflix.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F32FDE1F2E17947300B80BED /* RecommendedMovieCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32FDE1E2E17947300B80BED /* RecommendedMovieCell.swift */; };
 		F33B71372D89B66200A49099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33B71362D89B66200A49099 /* AppDelegate.swift */; };
 		F33B713B2D89B66200A49099 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33B713A2D89B66200A49099 /* MainViewController.swift */; };
 		F33B71402D89B66400A49099 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F33B713F2D89B66400A49099 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F32FDE1E2E17947300B80BED /* RecommendedMovieCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedMovieCell.swift; sourceTree = "<group>"; };
 		F33B71332D89B66200A49099 /* Uflix.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Uflix.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F33B71362D89B66200A49099 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F33B713A2D89B66200A49099 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				F3FC48662DD9F3CC0040DF9D /* DetailViewController.swift */,
 				F3FC48642DD9F2F20040DF9D /* DetailViewModel.swift */,
 				F33B71AC2D919D0600A49099 /* YoutubeViewController.swift */,
+				F32FDE1E2E17947300B80BED /* RecommendedMovieCell.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 				F33B71AF2D919EDE00A49099 /* SectionHeaderView.swift in Sources */,
 				F33B71812D903DBD00A49099 /* Movie.swift in Sources */,
 				F33B71832D903DC700A49099 /* Video.swift in Sources */,
+				F32FDE1F2E17947300B80BED /* RecommendedMovieCell.swift in Sources */,
 				F3FC48952DEAD5FC0040DF9D /* SuggestCell.swift in Sources */,
 				F3FC48652DD9F2F20040DF9D /* DetailViewModel.swift in Sources */,
 				F3FC48472DD332400040DF9D /* MainViewModel.swift in Sources */,

--- a/Uflix/Common/MovieService.swift
+++ b/Uflix/Common/MovieService.swift
@@ -13,6 +13,10 @@ enum TMDBEndpoint {
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         return URL(string: "https://api.themoviedb.org/3/search/movie?api_key=\(APIKeys.tmdb)&query=\(encoded)")
     }
+    
+    static func movieRecommendations(movieId: Int) -> URL? {
+            return URL(string: "https://api.themoviedb.org/3/movie/\(movieId)/recommendations?api_key=\(APIKeys.tmdb)")
+        }
 }
 
 class MovieService {
@@ -25,5 +29,15 @@ class MovieService {
         return NetworkManager.shared.fetch(url: url)
             .asObservable()
             .map{ (response: MovieResponse) in response.results }
+    }
+    
+    static func fetchRecommendations(for movieId: Int) -> Observable<[Movie]> {
+        guard let url = TMDBEndpoint.movieRecommendations(movieId: movieId) else {
+            return .error(NetworkError.invalidUrl)
+        }
+        
+        return NetworkManager.shared.fetch(url: url)
+            .asObservable()
+            .map { (response: MovieResponse) in response.results }
     }
 }

--- a/Uflix/Scene/Detail/DetailViewController.swift
+++ b/Uflix/Scene/Detail/DetailViewController.swift
@@ -75,6 +75,36 @@ class DetailViewController: UIViewController {
         return stack
     }()
     
+    private let recommendedTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "추천 콘텐츠"
+        label.font = .boldSystemFont(ofSize: 18)
+        label.textColor = UIColor.AppColor.textPrimary
+        return label
+    }()
+    
+    private let recommendedCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = 12
+        layout.minimumLineSpacing = 12
+        layout.itemSize = CGSize(width: 100, height: 170)
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = UIColor.AppColor.background
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.register(RecommendedMovieCell.self, forCellWithReuseIdentifier: RecommendedMovieCell.identifier)
+        return collectionView
+    }()
+
+    private let dummyMovies: [Movie] = [
+        Movie(id: 1, title: "인셉션", posterPath: "/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg", overview: nil),
+        Movie(id: 2, title: "인터스텔라", posterPath: "/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg", overview: nil),
+        Movie(id: 3, title: "다크 나이트", posterPath: "/1hRoyzDtpgMU7Dz4JF22RANzQO7.jpg", overview: nil),
+        Movie(id: 4, title: "테넷", posterPath: "/k68nPLbIST6NP96JmTxmZijEvCA.jpg", overview: nil)
+    ]
+
+    
     init(viewModel: DetailViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -88,6 +118,7 @@ class DetailViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         bind()
+        bindDummyRecommendedMovies()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -187,6 +218,7 @@ class DetailViewController: UIViewController {
         setupVideoSection()
         setupStackView()
         setupButtons()
+        setupRecommendedSection()
     }
     
     private func setupVideoSection() {
@@ -268,17 +300,43 @@ class DetailViewController: UIViewController {
         buttonStackView.snp.makeConstraints {
             $0.top.equalTo(stackView.snp.bottom).offset(16)
             $0.left.equalToSuperview().inset(8)
-            $0.bottom.equalToSuperview().inset(20)
         }
         
         likeButton.snp.makeConstraints {
             $0.width.height.equalTo(60)
         }
-        
 
         buttonStackView.addArrangedSubview(likeButton)
         buttonStackView.addArrangedSubview(shareButton)
     }
+    
+    private func setupRecommendedSection() {
+        contentView.addSubview(recommendedTitleLabel)
+        contentView.addSubview(recommendedCollectionView)
+        
+        recommendedTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(buttonStackView.snp.bottom).offset(32)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        recommendedCollectionView.snp.makeConstraints {
+            $0.top.equalTo(recommendedTitleLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(170)
+            $0.bottom.equalToSuperview().inset(20) // 중요: 전체 scrollView contentView 끝 지정
+        }
+    }
+    
+    private func bindDummyRecommendedMovies() {
+        Observable.just(dummyMovies)
+            .bind(to: recommendedCollectionView.rx.items(
+                cellIdentifier: RecommendedMovieCell.identifier,
+                cellType: RecommendedMovieCell.self)) { _, movie, cell in
+                    cell.configure(with: movie)
+            }
+            .disposed(by: disposeBag)
+    }
+
 
     private func configure(movie: Movie) {
         titleLabel.text = movie.title

--- a/Uflix/Scene/Detail/DetailViewController.swift
+++ b/Uflix/Scene/Detail/DetailViewController.swift
@@ -11,7 +11,7 @@ import YouTubeiOSPlayerHelper
 import RxSwift
 import Kingfisher
 
-class DetailViewController: UIViewController {
+class DetailViewController: BaseViewController {
     private let viewModel: DetailViewModel
     private let disposeBag = DisposeBag()
     

--- a/Uflix/Scene/Detail/DetailViewController.swift
+++ b/Uflix/Scene/Detail/DetailViewController.swift
@@ -97,14 +97,6 @@ class DetailViewController: UIViewController {
         return collectionView
     }()
 
-    private let dummyMovies: [Movie] = [
-        Movie(id: 1, title: "인셉션", posterPath: "/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg", overview: nil),
-        Movie(id: 2, title: "인터스텔라", posterPath: "/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg", overview: nil),
-        Movie(id: 3, title: "다크 나이트", posterPath: "/1hRoyzDtpgMU7Dz4JF22RANzQO7.jpg", overview: nil),
-        Movie(id: 4, title: "테넷", posterPath: "/k68nPLbIST6NP96JmTxmZijEvCA.jpg", overview: nil)
-    ]
-
-    
     init(viewModel: DetailViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -118,7 +110,7 @@ class DetailViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         bind()
-        bindDummyRecommendedMovies()
+        bindRecommendedMovies()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -201,6 +193,23 @@ class DetailViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { error in
                 print("❗️Error: \(error.localizedDescription)")
+            }).disposed(by: disposeBag)
+    }
+
+    private func bindRecommendedMovies() {
+        viewModel.recommendedMoviesRelay
+            .bind(to: recommendedCollectionView.rx.items(
+                cellIdentifier: RecommendedMovieCell.identifier,
+                cellType: RecommendedMovieCell.self)) { _, movie, cell in
+                    cell.configure(with: movie)
+            }
+            .disposed(by: disposeBag)
+        
+        recommendedCollectionView.rx.modelSelected(Movie.self)
+            .subscribe(onNext: { [weak self] movie in
+                let detailVM = DetailViewModel(movie: movie)
+                let detailVC = DetailViewController(viewModel: detailVM)
+                self?.navigationController?.pushViewController(detailVC, animated: true)
             }).disposed(by: disposeBag)
     }
     
@@ -326,17 +335,6 @@ class DetailViewController: UIViewController {
             $0.bottom.equalToSuperview().inset(20) // 중요: 전체 scrollView contentView 끝 지정
         }
     }
-    
-    private func bindDummyRecommendedMovies() {
-        Observable.just(dummyMovies)
-            .bind(to: recommendedCollectionView.rx.items(
-                cellIdentifier: RecommendedMovieCell.identifier,
-                cellType: RecommendedMovieCell.self)) { _, movie, cell in
-                    cell.configure(with: movie)
-            }
-            .disposed(by: disposeBag)
-    }
-
 
     private func configure(movie: Movie) {
         titleLabel.text = movie.title

--- a/Uflix/Scene/Detail/DetailViewModel.swift
+++ b/Uflix/Scene/Detail/DetailViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import RxCocoa
 
 class DetailViewModel {
     struct Input {
@@ -19,6 +20,7 @@ class DetailViewModel {
         let trailerKey: Observable<String>
         let likeButtonState: Observable<LikeButtonState>
         let error: Observable<Error>
+        let recommendedMovies: Observable<[Movie]>
     }
     
     private let disposeBag = DisposeBag()
@@ -28,6 +30,7 @@ class DetailViewModel {
     let trailerKeySubject = ReplaySubject<String>.create(bufferSize: 1)
     let errorSubject = PublishSubject<Error>()
     let isFavoriteSubject = BehaviorSubject<Bool>(value: false)
+    let recommendedMoviesRelay = BehaviorRelay<[Movie]>(value: [])
     
     
     init(movie: Movie) {
@@ -35,6 +38,7 @@ class DetailViewModel {
         self.movieDetailSubject = BehaviorSubject(value: movie)
         checkFavoriteStatus()
         fetchTrailerKey()
+        fetchRecommendations()
     }
 
     func transform(input: Input) -> Output {
@@ -53,7 +57,8 @@ class DetailViewModel {
             isFavorite: isFavoriteSubject.asObservable(),
             trailerKey: trailerKeySubject.asObservable(),
             likeButtonState: likeButtonState,
-            error: errorSubject.asObservable()
+            error: errorSubject.asObservable(),
+            recommendedMovies: recommendedMoviesRelay.asObservable()
         )
     }
     
@@ -101,6 +106,20 @@ class DetailViewModel {
                 self?.trailerKeySubject.onNext(key)
             }, onFailure: { [weak self] error in
                 self?.trailerKeySubject.onError(error)
+                self?.errorSubject.onNext(error)
+            }).disposed(by: disposeBag)
+    }
+    
+    func fetchRecommendations() {
+        MovieService.fetchRecommendations(for: movie.id)
+            .subscribe(onNext: { [weak self] movies in
+                print("✅ 추천 영화 목록:")
+                movies.forEach { movie in
+                    print("\(movie.title ?? "제목 없음")")
+                }
+                self?.recommendedMoviesRelay.accept(movies)
+            }, onError:  { [weak self] error in
+                print("❌ 추천 영화 가져오기 실패:", error.localizedDescription)
                 self?.errorSubject.onNext(error)
             }).disposed(by: disposeBag)
     }

--- a/Uflix/Scene/Detail/DetailViewModel.swift
+++ b/Uflix/Scene/Detail/DetailViewModel.swift
@@ -117,7 +117,7 @@ class DetailViewModel {
                 movies.forEach { movie in
                     print("\(movie.title ?? "제목 없음")")
                 }
-                self?.recommendedMoviesRelay.accept(movies)
+                self?.recommendedMoviesRelay.accept(Array(movies.prefix(10)))
             }, onError:  { [weak self] error in
                 print("❌ 추천 영화 가져오기 실패:", error.localizedDescription)
                 self?.errorSubject.onNext(error)

--- a/Uflix/Scene/Detail/RecommendedMovieCell.swift
+++ b/Uflix/Scene/Detail/RecommendedMovieCell.swift
@@ -1,0 +1,63 @@
+//
+//  RecommendedMovieCell.swift
+//  Uflix
+//
+//  Created by 정유진 on 7/4/25.
+//
+
+import UIKit
+import SnapKit
+import Kingfisher
+
+class RecommendedMovieCell: UICollectionViewCell {
+    static let identifier = "RecommendedMovieCell"
+    
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+    
+    override init(frame: CGRect) {
+            super.init(frame: frame)
+            setupUI()
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+    private func setupUI() {
+        contentView.backgroundColor = UIColor.AppColor.background
+        
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        imageView.backgroundColor = .darkGray
+        
+        titleLabel.font = .systemFont(ofSize: 12)
+        titleLabel.textColor = UIColor.AppColor.textSecondary
+        titleLabel.numberOfLines = 2
+        titleLabel.textAlignment = .center
+        
+        contentView.addSubview(imageView)
+        contentView.addSubview(titleLabel)
+        
+        imageView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(imageView.snp.width).multipliedBy(1.5)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.bottom).offset(4)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    func configure(with movie: Movie) {
+        titleLabel.text = movie.title
+        if let path = movie.posterPath {
+            let url = URL(string: "https://image.tmdb.org/t/p/w500\(path)")
+            imageView.kf.setImage(with: url)
+        } else {
+            imageView.image = UIImage(systemName: "photo")
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 디테일 화면에 추천 콘텐츠 섹션 추가

## 🚀 Description
- `MovieService`에 `fetchRecommendations(for:)` 메서드 추가
- `DetailViewModel`에 추천 콘텐츠 요청 로직 및 Relay 추가
- `DetailViewController`에 가로 스크롤 컬렉션 뷰(`RecommendedMovieCell`) 추가
- 추천 콘텐츠는 최대 10개까지 제한하여 UI 집중도 유지
- 셀 클릭 시 해당 영화의 `DetailViewController`로 이동

## 🔍 Related Issue
- 이슈 번호: #31

## 📸 Screenshot
|    기능    |   이미지   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/6ab06f71-93ad-4c10-8a57-443c50fb972a" width ="250">|

## 📢 Notes
- 더미 데이터 바인딩 → API 연동 완료
- 추천 콘텐츠가 없는 경우 섹션이 표시되지 않도록 처리 (옵션)
- 기존 기능에 영향 없음 (trailer, 좋아요, 공유 등)

